### PR TITLE
Simplify dependencies

### DIFF
--- a/dimensions.go
+++ b/dimensions.go
@@ -3,12 +3,12 @@ package screen
 import (
 	"os"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // Size returns the width and height of the terminal screen
 func Size() (int, int) {
-	w, h, err := terminal.GetSize(int(os.Stdout.Fd()))
+	w, h, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
 		return 0, 0
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,7 @@
 module github.com/inancgumus/screen
+
+go 1.19
+
+require golang.org/x/term v0.2.0
+
+require golang.org/x/sys v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.2.0 h1:ljd4t30dBnAvMZaQCevtY0xLLD0A+bRZXbgLMLU1F/A=
+golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.2.0 h1:z85xZCsEl7bi/KwbNADeBYoOP0++7W1ipu+aGnpwzRM=
+golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=


### PR DESCRIPTION
I checked source code of the crypto/ssh/terminal package... and it turns out the GetSize function is also a wrapper function for one from the term package, so a good practice would be a decrease in dependency levels