### PR TITLE
func MoveCursor(x, y uint16) error

### DIFF
--- a/clear_others.go
+++ b/clear_others.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package screen
@@ -12,4 +13,20 @@ func Clear() {
 // MoveTopLeft moves the cursor to the top left position of the screen
 func MoveTopLeft() {
 	fmt.Print("\033[H")
+}
+
+// MoveCursor moves the cursor anywhere on the screen
+// returns outOfRange error if (x, y) is bigger than screen.Size()
+func MoveCursor(x, y uint16) error {
+	if a, b := Size(); int(x) > a || int(y) > b {
+		return outOfRange{}
+	}
+
+	fmt.Printf("\033[%d;%dH", x, y)
+}
+
+type outOfRange struct{}
+
+func (o outOfRange) Error() string {
+	return "(x, y) out of range"
 }

--- a/clear_others.go
+++ b/clear_others.go
@@ -19,14 +19,8 @@ func MoveTopLeft() {
 // returns outOfRange error if (x, y) is bigger than screen.Size()
 func MoveCursor(x, y uint16) error {
 	if a, b := Size(); int(x) > a || int(y) > b {
-		return outOfRange{}
+		return outOfRange{x, y}
 	}
 
 	fmt.Printf("\033[%d;%dH", x, y)
-}
-
-type outOfRange struct{}
-
-func (o outOfRange) Error() string {
-	return "(x, y) out of range"
 }

--- a/clear_others.go
+++ b/clear_others.go
@@ -23,4 +23,14 @@ func MoveCursor(x, y uint16) error {
 	}
 
 	fmt.Printf("\033[%d;%dH", x, y)
+	return nil
+}
+
+type outOfRange struct {
+	x uint16
+	y uint16
+}
+
+func (o outOfRange) Error() string {
+	return fmt.Sprintf("(%d, %d) out of range", o.x, o.y)
 }

--- a/clear_windows.go
+++ b/clear_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package screen
@@ -44,6 +45,23 @@ func MoveTopLeft() {
 	)
 }
 
+// MoveCursor moves the cursor anywhere on the screen
+// returns outOfRange error if (x, y) is bigger than screen.Size()
+func MoveCursor(x, y uint16) error {
+	if a, b := Size(); int(x) > a || int(y) > b {
+		return outOfRange{}
+	}
+
+	h := getScreen()
+
+	xSetConsoleCursorPosition.Call(
+		uintptr(h.handle),
+		*(*uintptr)(unsafe.Pointer(&coord{x, y})),
+	)
+
+	return nil
+}
+
 func getScreen() consoleScreenBufferInfoHandle {
 	h := consoleScreenBufferInfoHandle{
 		handle: syscall.Handle(os.Stdout.Fd()),
@@ -66,15 +84,15 @@ var (
 )
 
 type (
-	wchar uint16
+	// wchar uint16
 	short int16
 	dword uint32
 	word  uint16
 )
 
 type coord struct {
-	x short
-	y short
+	x uint16
+	y uint16
 }
 
 type smallRect struct {
@@ -95,4 +113,10 @@ type consoleScreenBufferInfo struct {
 type consoleScreenBufferInfoHandle struct {
 	handle syscall.Handle
 	consoleScreenBufferInfo
+}
+
+type outOfRange struct{}
+
+func (o outOfRange) Error() string {
+	return "(x, y) out of range"
 }

--- a/clear_windows.go
+++ b/clear_windows.go
@@ -4,6 +4,7 @@
 package screen
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 	"unsafe"
@@ -49,7 +50,7 @@ func MoveTopLeft() {
 // returns outOfRange error if (x, y) is bigger than screen.Size()
 func MoveCursor(x, y uint16) error {
 	if a, b := Size(); int(x) > a || int(y) > b {
-		return outOfRange{}
+		return outOfRange{x, y}
 	}
 
 	h := getScreen()
@@ -115,8 +116,11 @@ type consoleScreenBufferInfoHandle struct {
 	consoleScreenBufferInfo
 }
 
-type outOfRange struct{}
+type outOfRange struct {
+	x uint16
+	y uint16
+}
 
 func (o outOfRange) Error() string {
-	return "(x, y) out of range"
+	return fmt.Sprintf("(%d, %d) out of range", o.x, o.y)
 }

--- a/dimensions.go
+++ b/dimensions.go
@@ -3,7 +3,7 @@ package screen
 import (
 	"os"
 
-	"golang.org/x/crypto/ssh/terminal"
+	terminal "golang.org/x/term"
 )
 
 // Size returns the width and height of the terminal screen

--- a/example/main.go
+++ b/example/main.go
@@ -19,5 +19,11 @@ func main() {
 		fmt.Println(time.Now())
 
 		time.Sleep(time.Second)
+
+		err := screen.MoveCursor(0, 0)
+		if err == nil {
+
+			time.Sleep(time.Second)
+		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,10 @@
 module github.com/inancgumus/screen
+
+go 1.21.6
+
+require golang.org/x/crypto v0.18.0
+
+require (
+	golang.org/x/sys v0.16.0 // indirect
+	golang.org/x/term v0.16.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/crypto v0.18.0 h1:PGVlW0xEltQnzFZ55hkuX5+KLyrMYhHld1YHO4AKcdc=
+golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.16.0 h1:m+B6fahuftsE9qjo0VWp2FW0mB3MTJvR0BaMQrq0pmE=
+golang.org/x/term v0.16.0/go.mod h1:yn7UURbUtPyrVJPGPq404EukNFxcm/foM+bV/bfcDsY=


### PR DESCRIPTION
Added ``MoveCursor`` function to move the cursor anywhere on the terminal, both on ``clear_others.go`` and ``clear_windows.go``.  

The function takes **uint16** as opposed to **short** (int16) because there are no negative coordinates. On windows also changed the ``coords{x, y}`` struct to take in **uint16** rather than **short**.

Added ``outOfRange`` error so the function can return it if the coordinates are out of range of the terminal size (``screen.Size()``).

Added a function call to the example (main) package.

Ran `go mod tidy`.